### PR TITLE
Fixed a bug in find_value_offset_v2 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sstb"
-version = "0.3.0-alpha"
+version = "0.3.1-alpha"
 authors = ["Igor Katson <igor.katson@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -29,7 +29,7 @@ criterion = "^0.3"
 rand = {version = "^0.7", features=["small_rng"]}
 crossbeam = "^0.7"
 rayon = "^1.3"
-rocksdb = "^0.13"
+rocksdb = "0.22.0"
 
 [profile.bench]
 lto = true

--- a/src/sstable/mod.rs
+++ b/src/sstable/mod.rs
@@ -84,8 +84,9 @@ mod tests {
     use std::collections::BTreeMap;
 
     fn write_basic_map(filename: &str, options: WriteOptions) {
-        let mut map = BTreeMap::new();
+        let mut map: BTreeMap<&[u8], &[u8]> = BTreeMap::new();
         map.insert(b"foo", b"some foo");
+        map.insert(b"fail", b"some fail");
         map.insert(b"bar", b"some bar");
         write_btree_map(&map, filename, Some(options)).unwrap();
     }

--- a/src/sstable/ondisk_format.rs
+++ b/src/sstable/ondisk_format.rs
@@ -122,7 +122,7 @@ pub fn find_value_offset_v2(buf: &[u8], key: &[u8]) -> Result<Option<(usize, usi
 
     let mut offset = 0;
     while offset < buf.len() {
-        let kvlength = bincode::deserialize::<KVLength>(&buf)?;
+        let kvlength = bincode::deserialize::<KVLength>(&buf[offset..])?;
         let (start_key, cursor) = {
             let key_start = offset + kvlen_encoded_size;
             let key_end = key_start + kvlength.key_length as usize;


### PR DESCRIPTION
Fixed a bug in `find_value_offset_v2` which causes the `KVLength` at the start of the chunk to be used instead of the one preceding each KV.

Given that the `KVLength` is written before each KV, it seems like keys and values of different lengths are intended to be supported.

Other Changes:

- Added a test which catches the bug.
- Bumped the version of rocksdb to latest since the old one would not build for me. 
- Bump patch release number for version to 0.3.1-alpha